### PR TITLE
Updated csproj to new SDK-style project format; fix custom chara ordering, vanishing sprites, chara handling in stories, support for more card options

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,43 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-debug",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/ExoLoader.sln",
+                "-c",
+                "Debug"
+            ],
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-release",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/ExoLoader.sln",
+                "-c",
+                "Release"
+            ],
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/ExoLoader/AddContentPatches.cs
+++ b/ExoLoader/AddContentPatches.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace ExoLoader
 {
@@ -134,6 +135,36 @@ namespace ExoLoader
                     }
                 }
 
+            }
+
+            // Chara.allCharas is the array used in CharasMenu to display the list of charas
+            // With this sorting, we maintain the order of original charas, but add custom charas with .canLove before original charas with .canLove = false
+            // This is done to maintain the order of charas in the menu, and to make it easier to find custom charas
+            ReorderCharasWithLinq();
+        }
+
+        public static void ReorderCharasWithLinq()
+        {
+            Chara.allCharas = Chara.allCharas
+                .OrderBy(GetCharaSortKey)
+                .ToList();
+        }
+
+        private static int GetCharaSortKey(Chara chara)
+        {
+            // Create sort keys to maintain desired order:
+            // 0: Chara with canLove = true
+            // 1: CustomChara with canLove = true
+            // 2: Chara with canLove = false
+            // 3: CustomChara with canLove = false
+
+            if (chara is CustomChara)
+            {
+                return chara.canLove ? 1 : 3;
+            }
+            else // Regular Chara
+            {
+                return chara.canLove ? 0 : 2;
             }
         }
 

--- a/ExoLoader/AddContentPatches.cs
+++ b/ExoLoader/AddContentPatches.cs
@@ -168,8 +168,6 @@ namespace ExoLoader
             }
         }
 
-
-
         public static void LoadCustomContent(string contentType)
         {
             ModInstance.instance.Log("Checking CustomContent folders");

--- a/ExoLoader/CFileManager.cs
+++ b/ExoLoader/CFileManager.cs
@@ -363,7 +363,7 @@ namespace ExoLoader
                 Byte[] bytes = null;
                 try
                 {
-                    texture = new Texture2D(2,2);
+                    texture = new Texture2D(2, 2);
                     bytes = File.ReadAllBytes(imagePath);
                     ImageConversion.LoadImage(texture, bytes);
                     texture.Apply();
@@ -371,7 +371,10 @@ namespace ExoLoader
                     int targetHeightInUnits = targetHeight;
                     float density = height / targetHeightInUnits;
                     image = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0), density);
-                } catch (Exception e)
+                    // Setting name for chara sprites allows clicking interaction, speaker change animation, love bubbles, etc.
+                    image.name = imageName;
+                }
+                catch (Exception e)
                 {
                     ModInstance.log("Couldn't make sprite from file " + TrimFolderName(imagePath));
                     ModInstance.log(texture == null ? "The texture is null" : texture.isReadable.ToString());

--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -74,7 +74,7 @@ namespace ExoLoader
                                             DataDebugHelper.PrintDataError("Unexpected error when loading " + Path.GetFileNameWithoutExtension(file), ex.Message);
                                         }
                                         throw ex;
-                                        }
+                                    }
                                 }
                             }
 
@@ -249,6 +249,69 @@ namespace ExoLoader
                         DataDebugHelper.PrintDataError(Path.GetFileNameWithoutExtension(file) + "has invalid suit", "Valid suits are limited to wild, physical, mental and social");
                         break;
                     }
+            }
+
+            try
+            {
+                string howGetValue = data.ContainsKey("HowGet") ? ((string)data["HowGet"]).ToLower() : "none";
+
+                switch (howGetValue)
+                {
+                    case "unique":
+                        {
+                            cardData.howGet = HowGet.unique;
+                            break;
+                        }
+                    case "training":
+                        {
+                            cardData.howGet = HowGet.training;
+                            break;
+                        }
+                    case "trainingBuy":
+                        {
+                            cardData.howGet = HowGet.trainingBuy;
+                            break;
+                        }
+                    case "shopDefault":
+                        {
+                            cardData.howGet = HowGet.shopDefault;
+                            break;
+                        }
+                    case "shopClothes":
+                        {
+                            cardData.howGet = HowGet.shopClothes;
+                            break;
+                        }
+                    case "shopWeapons":
+                        {
+                            cardData.howGet = HowGet.shopWeapons;
+                            break;
+                        }
+                    case "shopGadgets":
+                        {
+                            cardData.howGet = HowGet.shopGadgets;
+                            break;
+                        }
+                    case "none":
+                    default:
+                        {
+                            cardData.howGet = HowGet.none;
+                            break;
+                        }
+                }
+
+                if (data.TryGetValue("UpgradeFrom", out object upgradeFromCardID))
+                {
+                    cardData.upgradeFromCardID = (string)upgradeFromCardID;
+                }
+                else
+                {
+                    cardData.upgradeFromCardID = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                ModInstance.log("Invalid HowGet/UpgradeFrom value in " + Path.GetFileNameWithoutExtension(file) + ": " + ex.Message);
             }
 
             if (data.TryGetValue("ArtistName", out object artistName))

--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -212,6 +212,11 @@ namespace ExoLoader
                         cardData.type = CardType.memory; 
                         break;
                     }
+                case "gear":
+                    {
+                        cardData.type = CardType.gear;
+                        break;
+                    }
                 default:
                     {
                         DataDebugHelper.PrintDataError(Path.GetFileNameWithoutExtension(file) + " has invalid or unsupported type", "Only memory type cards are currently supported");
@@ -267,27 +272,27 @@ namespace ExoLoader
                             cardData.howGet = HowGet.training;
                             break;
                         }
-                    case "trainingBuy":
+                    case "trainingbuy":
                         {
                             cardData.howGet = HowGet.trainingBuy;
                             break;
                         }
-                    case "shopDefault":
+                    case "shopdefault":
                         {
                             cardData.howGet = HowGet.shopDefault;
                             break;
                         }
-                    case "shopClothes":
+                    case "shopclothes":
                         {
                             cardData.howGet = HowGet.shopClothes;
                             break;
                         }
-                    case "shopWeapons":
+                    case "shopweapons":
                         {
                             cardData.howGet = HowGet.shopWeapons;
                             break;
                         }
-                    case "shopGadgets":
+                    case "shopgadgets":
                         {
                             cardData.howGet = HowGet.shopGadgets;
                             break;
@@ -308,10 +313,19 @@ namespace ExoLoader
                 {
                     cardData.upgradeFromCardID = null;
                 }
+
+                if (data.TryGetValue("Kudos", out object kudoCost))
+                {
+                    cardData.kudoCost = ((string)kudoCost).ParseInt();
+                }
+                else
+                {
+                    cardData.kudoCost = 0;
+                }
             }
             catch (Exception ex)
             {
-                ModInstance.log("Invalid HowGet/UpgradeFrom value in " + Path.GetFileNameWithoutExtension(file) + ": " + ex.Message);
+                ModInstance.log("Invalid new field value in " + Path.GetFileNameWithoutExtension(file) + ": " + ex.Message);
             }
 
             if (data.TryGetValue("ArtistName", out object artistName))

--- a/ExoLoader/CustomElements/CustomCardData.cs
+++ b/ExoLoader/CustomElements/CustomCardData.cs
@@ -25,7 +25,7 @@ namespace ExoLoader
         public string artistAt;
         public string artistLink;
 
-        private int kudoCost = 0;
+        public int kudoCost = 0;
 
         public List<CardAbilityType> abilityIds = new List<CardAbilityType>();
         public List<int> abilityValues = new List<int>();

--- a/ExoLoader/CustomElements/CustomCardData.cs
+++ b/ExoLoader/CustomElements/CustomCardData.cs
@@ -19,6 +19,8 @@ namespace ExoLoader
         public int level;
         public CardSuit suit;
         public int value;
+        public string upgradeFromCardID;
+        public HowGet howGet;
         public string artist;
         public string artistAt;
         public string artistLink;
@@ -39,8 +41,8 @@ namespace ExoLoader
                 originalAbilityValues = abilityValues,
                 originalAbilitySuits = abilitySuits,
                 kudosCost = kudoCost,
-                upgradeFromCardID = null,
-                howGet = HowGet.none,
+                upgradeFromCardID = upgradeFromCardID,
+                howGet = howGet,
                 artistName = artist,
                 artistSocialAt = artistAt,
                 artistSocialUrl = artistLink

--- a/ExoLoader/ExoLoader.csproj
+++ b/ExoLoader/ExoLoader.csproj
@@ -1,98 +1,42 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{93B8D51F-8938-4EDB-A824-914B27FB79A4}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ExoLoader</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyName>ExoLoader</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <RootNamespace>ExoLoader</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <BepInExPluginGuid>ExoLoaderInject</BepInExPluginGuid>
+    <BepInExPluginName>ExoLoader</BepInExPluginName>
+    <BepInExPluginVersion>1.0</BepInExPluginVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RestoreAdditionalProjectSources>
+      https://api.nuget.org/v3/index.json;
+      https://nuget.bepinex.dev/v3/index.json;
+      https://nuget.samboy.dev/v3/index.json
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\dlls\0Harmony.dll</HintPath>
-    </Reference>
+    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="UnityEngine.Modules" Version="2021.2.14" IncludeAssets="compile" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Game-specific assemblies that need manual references -->
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\dlls\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)lib\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="spine-unity">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\Exocolonist_Data\Managed\spine-unity.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\Exocolonist_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\Exocolonist_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\Exocolonist_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Exocolonist\Exocolonist_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(SolutionDir)lib\spine-unity.dll</HintPath>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Debugging\DataDebugHelper.cs" />
-    <Compile Include="MapSpots\AddMapSpotPatches.cs" />
-    <Compile Include="AddContentPatches.cs" />
-    <Compile Include="CustomElements\CharaData.cs" />
-    <Compile Include="CustomElements\CustomCardData.cs" />
-    <Compile Include="CustomElements\CustomChara.cs" />
-    <Compile Include="CustomContentParser.cs" />
-    <Compile Include="CustomElements\CustomJobData.cs" />
-    <Compile Include="MapSpots\CustomMapManager.cs" />
-    <Compile Include="CFileManager.cs" />
-    <Compile Include="ImagePatches.cs" />
-    <Compile Include="Injector.cs" />
-    <Compile Include="MapSpots\CustomMapObjectMaker.cs" />
-    <Compile Include="StoryPatches\LinePointer.cs" />
-    <Compile Include="ModInstance.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StoryPatches\StoryPatch.cs" />
-    <Compile Include="StoryPatches\StoryPatchManager.cs" />
-    <Compile Include="StoryPatches\StoryPatchType.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <!-- All .cs files are automatically included by the SDK -->
+
 </Project>

--- a/ExoLoader/MapSpots/AddMapSpotPatches.cs
+++ b/ExoLoader/MapSpots/AddMapSpotPatches.cs
@@ -21,6 +21,7 @@ namespace ExoLoader
             {
                 return;
             }
+
             string scene = MapManager.currentScene.RemoveStart("Colony").ToLower();
             string season = Princess.season.seasonID;
             ModInstance.log(season);
@@ -28,7 +29,8 @@ namespace ExoLoader
 
             foreach (CustomChara cC in CustomChara.customCharasById.Values)
             {
-                if (cC.data.onMap && ( !cC.data.helioOnly || scene.Equals("helio"))) {
+                if (cC.data.onMap && (!cC.data.helioOnly || scene.Equals("helio")))
+                {
                     Tuple<GameObject, Transform> pair = CustomMapObjectMaker.MakeCustomMapObject(cC.charaID, season, week, scene);
 
                     if (pair != null && pair.Item1 != null && pair.Item2 != null)

--- a/ExoLoader/MapSpots/CustomMapObjectMaker.cs
+++ b/ExoLoader/MapSpots/CustomMapObjectMaker.cs
@@ -72,7 +72,16 @@ namespace ExoLoader
             string maybeKey = customCharaId + "_" + season + "_month" + (season != "glow" ? week.ToString() : "");
             if (mapObjects.ContainsKey(maybeKey))
             {
-                return mapObjects[maybeKey];
+                Tuple<GameObject, Transform> pair = mapObjects[maybeKey];
+
+                if (pair != null && pair.Item1 != null && pair.Item2 != null)
+                {
+                    return pair;
+                }
+                else
+                {
+                    ModInstance.log("Map object or transform is null, continuing");
+                }
             }
             CustomChara cC = CustomChara.customCharasById[customCharaId];
             if (cC == null)
@@ -102,7 +111,17 @@ namespace ExoLoader
             ModInstance.log("Copied and modified map object");
 
             Tuple <GameObject,Transform> result = new Tuple<GameObject, Transform>(customMapObject, templateObject.transform.parent);
-            mapObjects.Add(maybeKey, result);
+
+            // The key may have existed, but the values were null
+            if (mapObjects.ContainsKey(maybeKey))
+            {
+                mapObjects[maybeKey] = result;
+            }
+            else
+            {
+                mapObjects.Add(maybeKey, result);
+            }
+
             return result;
         }
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,2 @@
+# This is a folder for external libraries, that we do not want to include in the repository.
+*.dll


### PR DESCRIPTION
Commit e1dbb656ce6c5d66533f4f7910060d8e020f40a7 upgrades csproj to new SDK-style (looks like old one is not well supported anymore), as well as replaces hardcoded DLL paths to NuGet packages (note: Harmony is now included in BepInEx). The manual references are placed in `lib` folder locally with gitignore configured to not commit them to the repo (for legal reasons).
There is also a `.vscode/tasks.json` configuration for easier build shortcuts within VSCode (not sure how to handle this in other editors).

Commit 83b328e8ec2352dfe5224e4a25d575c3ba97d3d7 sorts characters after import using the next priority:
- Base game characters with `canLove = true` (preserving original order from the game)
- Custom characters with `canLove = true`
- Base game characters with `canLove = false`
- Custom characters with `canLove = false`
This feels a bit more immersive, so no need to scroll down to see new friends :)

Commit 62b380534972391b078ab679b39db3c63b53dcc9 fixes one case of vanishing overworld sprites (the only one I could reliably reproduce).

Commit adbb81171cce80df64e225a87a230c75e7b31889 changes where the custom character sprite loading logic is hooked to, as well as making the custom characters clickable, enabling the dialogue and +/- love bubble animations during stories.

Commit 716272bf251f90166d820e34648b978f57bdcd7e adds support for unique/upgradable cards (these are usually the I/II/III cards you get from reputation with characters). For this cards should have `"HowGet": "unique",` and `"UpgradeFrom": "template1"` fields in json.

Commit e087dde6b040380827810053117b297f50c8caa2 adds support for gear cards that can be optionally added to shops.

FYI: Some spacing/formatting changes were applied automatically by VSCode's format-on-save feature. No manual style changes intended, sorry!