### PR TITLE
Minor fix to background loading, show error when trying to modify an existing ending

### DIFF
--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -88,7 +88,7 @@ namespace ExoLoader
                             {
                                 if (file.EndsWith(".png"))
                                 {
-                                    string bgName = Path.GetFileName(file).Replace(".png", "");
+                                    string bgName = Path.GetFileName(file).Replace(".png", "").ToLower();
                                     if (!Singleton<AssetManager>.instance.backgroundAndEndingNames.Contains(bgName))
                                     {
                                         ModInstance.log("Found bg " +  bgName);
@@ -531,12 +531,20 @@ namespace ExoLoader
                 skills[i] = Skill.FromID(skillsStrings[i]);
             }
 
+            if (Ending.FromID(ID) != null)
+            {
+                ModInstance.log("Ending with ID " + ID + " already exists, skipping creation");
+                DataDebugHelper.PrintDataError("Ending with ID " + ID + " already exists", "If you want to change the ending, please change the ID in the json file to something else. Editing existing endings is not supported at the moment.");
+                return;
+            }
+
+            ModInstance.log("Creating ending with ID " + ID);
             Ending ending = new Ending(ID, name, preamble, requiredMemories, requiredJobs, extraJobs, skills, chara, location);
 
             string bg = data.ContainsKey("Background") ? (string)data["Background"] : null;
             if (bg != null)
             {
-                Singleton<AssetManager>.instance.backgroundAndEndingNames = Singleton<AssetManager>.instance.backgroundAndEndingNames.ToList<string>().AddItem(bg).ToArray();
+                Singleton<AssetManager>.instance.backgroundAndEndingNames = Singleton<AssetManager>.instance.backgroundAndEndingNames.ToList<string>().AddItem(bg.ToLower()).ToArray();
             }
             ModInstance.log("Parsed and created ending");
         }

--- a/ExoLoader/ImagePatches.cs
+++ b/ExoLoader/ImagePatches.cs
@@ -141,22 +141,28 @@ namespace ExoLoader
 
         [HarmonyPatch(typeof(AssetManager))]
         [HarmonyPatch(nameof(AssetManager.LoadBackgroundOrEndingSprite))]
-        [HarmonyPrefix]
-        public static bool LoadCustomBackground(ref Sprite __result, string spriteName)
+        [HarmonyPostfix]
+        public static void LoadCustomBackground(ref Sprite __result, string spriteName)
         {
-            //ModInstance.log("Loading custom background with id " + spriteName);
-            string folder = CustomContentParser.customBackgrounds.GetSafe(spriteName);
-            if (folder != null)
+            if (__result)
             {
-                Texture2D bgTexture = CFileManager.GetTexture(Path.Combine(folder, spriteName + ".png"));
-                __result = Sprite.Create(bgTexture, new Rect(0, 0, bgTexture.width, bgTexture.height), new Vector2(0.5f, 0), 1);
-                return false;
-            }
-            else
-            {
-                return true;
+                return;
             }
 
+            try
+            {
+                ModInstance.log("Loading custom background with id " + spriteName);
+                string folder = CustomContentParser.customBackgrounds.GetSafe(spriteName);
+                if (folder != null)
+                {
+                    Texture2D bgTexture = CFileManager.GetTexture(Path.Combine(folder, spriteName + ".png"));
+                    __result = Sprite.Create(bgTexture, new Rect(0, 0, bgTexture.width, bgTexture.height), new Vector2(0.5f, 0), 1);
+                }
+            }
+            catch (Exception e)
+            {
+                ModInstance.log($"Error loading custom background with id {spriteName}: {e}");
+            }
         }
 
         [HarmonyPatch(typeof(Result))]


### PR DESCRIPTION
Fix: Game always transforms background names to lower case, so if user added a picture with camelCase in it - it'll not load correctly. `File.ReadAllBytes` is not case-sensitive, so there is no need to force user to only add images in lowercase.

For endings: currently trying to modify an existing ending does not work, so this PR adds a log message and an error, we can add support for modifying endings later on.