### PR TITLE
Custom mem flags in result bubbles & button icons

### DIFF
--- a/ExoLoader/AddContentPatches.cs
+++ b/ExoLoader/AddContentPatches.cs
@@ -108,6 +108,7 @@ namespace ExoLoader
         public static void FinalizeLoading()
         {
             FinalizeCharacters();
+            LoadCustomContent("ScriptExtensions");
         }
 
         public static void FinalizeCharacters() //Loads likes, dislikes

--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -194,6 +194,11 @@ namespace ExoLoader
                                                 DataDebugHelper.PrintDataError("Unexpected error when loading script extension " + Path.GetFileNameWithoutExtension(file), ex.Message);
                                             }
                                             throw ex;
+                                        }
+                                    }
+                                }
+                                break;
+                            }
 
                         case "Collectibles":
                             {

--- a/ExoLoader/CustomContentParser.cs
+++ b/ExoLoader/CustomContentParser.cs
@@ -164,6 +164,34 @@ namespace ExoLoader
                                 }
                                 break;
                             }
+                        case "ScriptExtensions":
+                            {
+                                ModInstance.log("Parsing script extensions folder");
+                                foreach (string file in Directory.GetFiles(folder))
+                                {
+                                    if (file.EndsWith(".json"))
+                                    {
+                                        ModInstance.log("Parsing script extension file : " + Path.GetFileName(file));
+                                        try
+                                        {
+                                            ScriptExtensionsParser.ParseFile(file);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            if (ex is InvalidCastException)
+                                            {
+                                                DataDebugHelper.PrintDataError("Invalid cast when loading script extension " + Path.GetFileNameWithoutExtension(file), "This happens when there is missing quotation marks in the json, or if you put text where a number should be. Make sure everything is in order!");
+                                            }
+                                            else
+                                            {
+                                                DataDebugHelper.PrintDataError("Unexpected error when loading script extension " + Path.GetFileNameWithoutExtension(file), ex.Message);
+                                            }
+                                            throw ex;
+                                        }
+                                    }
+                                }
+                                break;
+                            }
                     }
                 }
             }

--- a/ExoLoader/ExoLoader.csproj
+++ b/ExoLoader/ExoLoader.csproj
@@ -35,6 +35,10 @@
       <HintPath>$(SolutionDir)lib\spine-unity.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>$(SolutionDir)lib\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <!-- All .cs files are automatically included by the SDK -->

--- a/ExoLoader/ScriptExtensions/CustomMemChange.cs
+++ b/ExoLoader/ScriptExtensions/CustomMemChange.cs
@@ -18,12 +18,15 @@ namespace ExoLoader
             if (!changesByID.ContainsKey(ID))
             {
                 changesByID.Add(ID, this);
-                ModInstance.instance.Log("Custom memory change created: " + id + " - " + name);
+                ModInstance.instance.Log("Custom memory change created: " + ID + " - " + name);
             }
             else
             {
                 ModInstance.instance.Log("Custom memory change with ID " + ID + " already exists. Skipping.");
             }
+
+            TextLocalized tl = new TextLocalized("memchange_" + ID);
+            tl.AddLocale(Locale.EN, name);
         }
     }
 }

--- a/ExoLoader/ScriptExtensions/CustomMemChange.cs
+++ b/ExoLoader/ScriptExtensions/CustomMemChange.cs
@@ -1,0 +1,29 @@
+
+using System.Collections.Generic;
+
+namespace ExoLoader
+{
+    public class CustomMemChange
+    {
+        public static Dictionary<string, CustomMemChange> changesByID = new Dictionary<string, CustomMemChange>();
+
+        public string ID; // key of the memory, will be like tammyConfidence for mem_tammyConfidence
+        public string name; // name for display
+
+        public CustomMemChange(string id, string name)
+        {
+            ID = id.ToLower();
+            this.name = name;
+
+            if (!changesByID.ContainsKey(ID))
+            {
+                changesByID.Add(ID, this);
+                ModInstance.instance.Log("Custom memory change created: " + id + " - " + name);
+            }
+            else
+            {
+                ModInstance.instance.Log("Custom memory change with ID " + ID + " already exists. Skipping.");
+            }
+        }
+    }
+}

--- a/ExoLoader/ScriptExtensions/CustomMemPatches.cs
+++ b/ExoLoader/ScriptExtensions/CustomMemPatches.cs
@@ -1,0 +1,187 @@
+using HarmonyLib;
+using UnityEngine.UI;
+using UnityEngine;
+
+namespace ExoLoader
+{
+    [HarmonyPatch]
+    public class CustomMemPatches
+    {
+        [HarmonyPatch(typeof(NWButtonResults), "IsShowableReq", MethodType.Normal)]
+        [HarmonyPostfix]
+        public static void IsShowableReqPatch(NWButtonResults __instance, ref bool __result, StoryReq req, Result result)
+        {
+            try
+            {
+                if (__result)
+                {
+                    return;
+                }
+
+                if (req.type == StoryReqType.memory && CustomMemChange.changesByID.ContainsKey(req.stringID))
+                {
+                    __result = true;
+                    return;
+                }
+            }
+            catch (System.Exception ex)
+            {
+                ModInstance.instance.Log("Error in IsShowableReqPatch: " + ex.Message);
+                ModInstance.instance.Log("Stack trace: " + ex.StackTrace);
+            }
+        }
+
+        [HarmonyPatch(typeof(NWButtonResults), "SetRequirement", MethodType.Normal)]
+        [HarmonyPostfix]
+        public static void SetRequirementPatch(NWButtonResults __instance, ref Image requirementIcon, StoryReq req, Result result)
+        {
+            try
+            {
+                if (req.type == StoryReqType.memory && CustomMemChange.changesByID.ContainsKey(req.stringID))
+                {
+                    ModInstance.instance.Log("Setting custom memory icon for " + req.stringID);
+                    CustomMemChange change = CustomMemChange.changesByID[req.stringID];
+                    bool flag = !req.Execute(result);
+                    string text = "other";
+                    string text2 = change.name;
+
+                    string tooltip3 = (req.compare != StoryReqCompare.lessThan) ? TextLocalized.Localize("button_req_equalOrGreater", text2, req.intValue + 1) : TextLocalized.Localize("button_req_lessThan", text2, req.intValue);
+
+                    NWButtonResultsSetIcon(__instance, ref requirementIcon, text, tooltip3, flag ? NWButtonResults.requirementNotMetColor : NWButtonResults.requirementMetColor);
+                    if (flag || PlatformUtils.useControllerTooltips)
+                    {
+                        __instance.tooltipText = tooltip3;
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                ModInstance.instance.Log("Error in SetRequirementPatch: " + ex.Message);
+                ModInstance.instance.Log("Stack trace: " + ex.StackTrace);
+            }
+        }
+
+        public static void NWButtonResultsSetIcon(NWButtonResults __instance, ref Image iconImage, string iconName, string tooltip = null, Color color = default(Color))
+        {
+            Color iconColor = color == default(Color) ? Color.white : color;
+
+            if (iconName.IsNullOrEmptyOrWhitespace())
+            {
+                ((Component)(object)iconImage).SetActiveMaybe(value: false);
+                return;
+            }
+
+            Sprite requirementIcon = AssetManager.GetRequirementIcon(iconName);
+            if (requirementIcon == null)
+            {
+                ((Component)(object)iconImage).SetActiveMaybe(value: false);
+                return;
+            }
+
+            ((Component)(object)iconImage).SetActiveMaybe();
+            iconImage.sprite = requirementIcon;
+            if (tooltip != null)
+            {
+                ((Component)(object)iconImage).GetComponentInChildren<Tooltippable>()?.SetText(tooltip);
+            }
+
+            iconImage.SetImageColor(iconColor);
+        }
+
+        [HarmonyPatch(typeof(Princess), nameof(Princess.IncrementMemory))]
+        [HarmonyPrefix]
+        public static void IncrementMemoryPatch(string id, int value = 1)
+        {
+            if (value != 0 && Princess.result != null && CustomMemChange.changesByID.ContainsKey(id))
+            {
+                ModInstance.instance.Log("Adding custom memory change for " + id);
+                Princess.result.AddSkillChange(new SkillChange(id, value));
+            }
+        }
+
+        // ResultsSkillBubble.SetContent
+        [HarmonyPatch(typeof(ResultsSkillBubble), nameof(ResultsSkillBubble.SetContent))]
+        [HarmonyPostfix]
+        public static void SetContentPatch(ResultsSkillBubble __instance, SkillChange change)
+        {
+            if (CustomMemChange.changesByID.ContainsKey(change.stringID))
+            {
+                ModInstance.instance.Log("Setting custom memory bubble for " + change.stringID);
+                __instance.SetActiveMaybe(value: true);
+                ResultsSkillBubbleSetIcon(__instance, "other", "other");
+                return;
+            }
+        }
+
+        public static void ResultsSkillBubbleSetIcon(ResultsSkillBubble __instance, string iconName, string bgName, Color color = default(Color))
+        {
+            Color iconColor = color == default(Color) ? Color.white : color;
+            Sprite requirementIcon = AssetManager.GetRequirementIcon(iconName);
+            if (requirementIcon == null)
+            {
+                __instance.SetActiveMaybe(value: false);
+                return;
+            }
+
+            __instance.bubbleIcon.sprite = requirementIcon;
+            Sprite resultBubbleBg = AssetManager.GetResultBubbleBg(bgName);
+            if (resultBubbleBg == null)
+            {
+                __instance.SetActiveMaybe(value: false);
+                return;
+            }
+
+            __instance.bubbleBg.sprite = resultBubbleBg;
+            __instance.bubbleIcon.SetImageColor(iconColor);
+        }
+
+        // SkillChange.GetFormattedString
+        [HarmonyPatch(typeof(SkillChange), nameof(SkillChange.GetFormattedString))]
+        [HarmonyPostfix]
+        public static void GetFormattedStringPatch(SkillChange __instance, ref string __result, bool bonusDetails = false, bool simpleBonusDetails = false)
+        {
+            if (__instance.stringID != null && CustomMemChange.changesByID.ContainsKey(__instance.stringID))
+            {
+                ModInstance.instance.Log("Formatting custom memory change string for " + __instance.stringID);
+
+                CustomMemChange change = CustomMemChange.changesByID[__instance.stringID];
+                int num = __instance.value.Clamp(-100, 100);
+                string text = num.ToSignedString() + " " + change.name;
+
+                // This part probably is not needed
+                if (__instance.bonusValue != 0 || !__instance.bonusText.IsNullOrEmptyOrWhitespace())
+                {
+                    if (bonusDetails)
+                    {
+                        string[] array = __instance.bonusText?.Split(new char[1] { ';' }, System.StringSplitOptions.RemoveEmptyEntries);
+                        if (array == null || array.Length == 0)
+                        {
+                            text = text + " (" + __instance.bonusValue.ToSignedString() + ")";
+                        }
+                        else if (array.Length == 1)
+                        {
+                            text = text + " (" + TextLocalized.Localize("battleBonus_from", __instance.bonusValue.ToSignedString(), array[0]) + ")";
+                        }
+                        else if (array.Length == 2)
+                        {
+                            string text6 = array.JoinSafe(" " + TextLocalized.Localize("battleBonus_and") + " ");
+                            text = text + " (" + TextLocalized.Localize("battleBonus_from", __instance.bonusValue.ToSignedString(), text6) + ")";
+                        }
+                        else
+                        {
+                            string text7 = array.JoinSafe(", ");
+                            text = text + " (" + TextLocalized.Localize("battleBonus_from", __instance.bonusValue.ToSignedString(), text7) + ")";
+                        }
+                    }
+                    else
+                    {
+                        text = text + " (" + __instance.bonusValue.ToSignedString() + ")";
+                    }
+                }
+
+                __result = text.ReplaceAll("  ", " ");
+                return;
+            }
+        }
+    }
+}

--- a/ExoLoader/ScriptExtensions/CustomMemPatches.cs
+++ b/ExoLoader/ScriptExtensions/CustomMemPatches.cs
@@ -31,63 +31,6 @@ namespace ExoLoader
             }
         }
 
-        [HarmonyPatch(typeof(NWButtonResults), "SetRequirement", MethodType.Normal)]
-        [HarmonyPostfix]
-        public static void SetRequirementPatch(NWButtonResults __instance, ref Image requirementIcon, StoryReq req, Result result)
-        {
-            try
-            {
-                if (req.type == StoryReqType.memory && CustomMemChange.changesByID.ContainsKey(req.stringID))
-                {
-                    ModInstance.instance.Log("Setting custom memory icon for " + req.stringID);
-                    CustomMemChange change = CustomMemChange.changesByID[req.stringID];
-                    bool flag = !req.Execute(result);
-                    string text = "other";
-                    string text2 = change.name;
-
-                    string tooltip3 = (req.compare != StoryReqCompare.lessThan) ? TextLocalized.Localize("button_req_equalOrGreater", text2, req.intValue + 1) : TextLocalized.Localize("button_req_lessThan", text2, req.intValue);
-
-                    NWButtonResultsSetIcon(__instance, ref requirementIcon, text, tooltip3, flag ? NWButtonResults.requirementNotMetColor : NWButtonResults.requirementMetColor);
-                    if (flag || PlatformUtils.useControllerTooltips)
-                    {
-                        __instance.tooltipText = tooltip3;
-                    }
-                }
-            }
-            catch (System.Exception ex)
-            {
-                ModInstance.instance.Log("Error in SetRequirementPatch: " + ex.Message);
-                ModInstance.instance.Log("Stack trace: " + ex.StackTrace);
-            }
-        }
-
-        public static void NWButtonResultsSetIcon(NWButtonResults __instance, ref Image iconImage, string iconName, string tooltip = null, Color color = default(Color))
-        {
-            Color iconColor = color == default(Color) ? Color.white : color;
-
-            if (iconName.IsNullOrEmptyOrWhitespace())
-            {
-                ((Component)(object)iconImage).SetActiveMaybe(value: false);
-                return;
-            }
-
-            Sprite requirementIcon = AssetManager.GetRequirementIcon(iconName);
-            if (requirementIcon == null)
-            {
-                ((Component)(object)iconImage).SetActiveMaybe(value: false);
-                return;
-            }
-
-            ((Component)(object)iconImage).SetActiveMaybe();
-            iconImage.sprite = requirementIcon;
-            if (tooltip != null)
-            {
-                ((Component)(object)iconImage).GetComponentInChildren<Tooltippable>()?.SetText(tooltip);
-            }
-
-            iconImage.SetImageColor(iconColor);
-        }
-
         [HarmonyPatch(typeof(Princess), nameof(Princess.IncrementMemory))]
         [HarmonyPrefix]
         public static void IncrementMemoryPatch(string id, int value = 1)

--- a/ExoLoader/ScriptExtensions/ScriptExtensionsParser.cs
+++ b/ExoLoader/ScriptExtensions/ScriptExtensionsParser.cs
@@ -1,0 +1,47 @@
+
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ExoLoader
+{
+    public class ScriptExtensionsParser
+    {
+        public static void ParseFile(string file)
+        {
+            ModInstance.instance.Log("Parsing script extensions");
+            string fullJson = File.ReadAllText(file);
+            if (fullJson == null || fullJson.Length == 0)
+            {
+                ModInstance.instance.Log("Couldn't read text for " + Path.GetFileNameWithoutExtension(file));
+                return;
+            }
+
+            Dictionary<string, object> data = JsonConvert.DeserializeObject<Dictionary<string, object>>(fullJson);
+            if (data == null || data.Count == 0)
+            {
+                ModInstance.instance.Log("Couldn't parse json for " + Path.GetFileName(file));
+                return;
+            }
+
+            string ID = (string)data["ID"];
+            string name = (string)data["Name"];
+            
+            switch ((string)data["Type"])
+            {
+                // MemChange is for cases like tammyConfidence, which is a normal memory flag, but has some additional display logic (results bubbles, displayed button requirements, etc.)
+                case "MemChange":
+                    {
+                        new CustomMemChange(ID, name);
+                        break;
+                    }
+                default:
+                    {
+                        ModInstance.instance.Log("Unknown type " + (string)data["Type"] + " for script extension " + ID);
+                        return;
+                    }
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
Adds ability for users to add their own variants of `tammyConfidence` and `tangHelp`.
On the inside they are just like your usual memory flags (`mem_tammyConfidence` or `mem_tangHelp`), but they have added UI elements - showing up changes in the results part of the dialogue window, showing icons for option requirements.
Theoretically it is possible to add custom icons for it, currently will utilize the same icon used for similar flags in game - `?`.

Example configuration:
```json
{
    "Type": "MemChange",
    "ID": "templateWarned",
    "Name": "Template Warned"
}
```

Example story:
```exoscript
=== testMemChange ==============================================
    ~set bg = engineering
    ~set left = none

    Hey, do we warn Template? [=mem_templateWarned]

    * Let us test!
        Yeah...

        -

        > warnings

    *= warnings

        ** Warn Template
            // this will have ? icon with +1 Template Warned tooltip
            ~set mem_templateWarned++

            Warned Template! [=mem_templateWarned]

            -

            > warnings

        ** Unwarn Template
            // this will have ? icon with -1 Template Warned tooltip
            ~set mem_templateWarned--

            Unwarned Template! [=mem_templateWarned]

            -

            > warnings

        ** Only clickable if warned Template twice
            // this option will be shown, but disabled until templateWarned is at least 2, option button will have a tooltip about it
            ~ifd mem_templateWarned >= 2

            You have warned Template twice! [=mem_templateWarned]

            -

            > warnings

        ** Only visible if warned Template three times
            // this option will not be shown until value is at least 3 (default behavior, no changes here)
            ~if mem_templateWarned >= 3

            You have warned Template three times! [=mem_templateWarned]

            -

            > warnings

        ** Only clickable if unwarned Template twice or more
            // this option will be shown, but disabled until templateWarned is at -2 or less, option button will have a tooltip about it
            ~ifd mem_templateWarned <= -2

            You have unwarned Template twice or more! [=mem_templateWarned]

            -

            > warnings

        ** Only visible if unwarned Template three times or more
            // this option will not be shown until value is -3 or less (default behavior, no changes here)
            ~if mem_templateWarned <= -3

            You have unwarned Template three times or more! [=mem_templateWarned]

            -

            > warnings

        ** Done!
            We are done with warnings!

    * Done
        Done with testing
```

![Screenshot 2025-05-30 145826](https://github.com/user-attachments/assets/73f7f60c-08db-4333-9a5f-63d876b213cf)
